### PR TITLE
bscn: Add text scanner library

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -960,6 +960,7 @@ INPUT                  = mainpage.md \
 	bspscq.h \
 	bent.h \
 	bsv.h \
+	bscn.h \
 	bstacktrace.h \
 	bcrash_handler.h \
 

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ bin/test-all: \
 		bhamt.h barena.h tests/bhamt/main.c \
 		bent.h tests/bent/shared.c tests/bent/component.c tests/bent/system.c tests/bent/reload.c \
 		bsv.h tests/bsv/shared.c tests/bsv/basic.c tests/bsv/versioning.c \
+		bscn.h tests/bscn/shared.c tests/bscn/basic.c tests/bscn/pos.c tests/bscn/sub.c \
 		bco.h tests/bco/shared.c tests/bco/basic.c tests/bco/cleanup.c tests/bco/subcoro.c tests/bco/clone.c \
 		tests/main.c
 	mkdir -p bin

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Collection of miscellaneous single-header libraries.
 |[qoi.h](qoi.h)|Quite OK image encoding/decoding|
 |[bent.h](bent.h)|Entity component system|
 |[bsv.h](bsv.h)|Binary seriallization with explicit versioning|
+|[bscn.h](tests/bscn)|Text scanner for hand-written parsers|
 |[bstacktrace.h](bstacktrace.h)|Portable stacktrace with source mapping|
 |[bcrash_handler.h](bcrash_handler.h)|Crash handler|
 

--- a/bscn.h
+++ b/bscn.h
@@ -1,0 +1,694 @@
+#ifndef BSCN_H
+#define BSCN_H
+
+/**
+ * @file
+ *
+ * @brief Text scanner for hand-written parsers.
+ *
+ * This is inspired by [bx::Scanner](https://bkaradzic.github.io/posts/scanner/).
+ *
+ * The scanner never allocates and never copies.
+ * All results are views (@ref bscn_str_t) into the original input and stay
+ * valid for as long as the input does.
+ *
+ * There is a single cursor and it only moves when explicitly told to:
+ *
+ * * `bscn_accept*` moves it forward past matched text.
+ * * `bscn_peek*` tests without moving.
+ * * @ref bscn_seek and @ref bscn_reset move it explicitly.
+ *
+ * A failed match returns an empty view anchored at the cursor and does not
+ * move it.
+ * "Matched nothing" and "did not match" both return an empty view.
+ * This is intentional: empty tokens are often valid (e.g: a URL without
+ * a path).
+ * Structural questions ("was the delimiter there?") should be answered
+ * separately by accepting or peeking the delimiter itself.
+ *
+ * Line endings: both `\n` and `\r\n` are handled transparently by
+ * @ref bscn_next_line and @ref bscn_accept_new_line.
+ * However, since views are zero-copy, a view that spans multiple lines will
+ * still contain the raw `\r` bytes.
+ * Prefer @ref bscn_next_line for content comparison, or clean up with
+ * @ref bscn_str_trim.
+ *
+ * A scanner can be bounded to a part of a document (a "sub-scanner") while
+ * still reporting positions in the coordinates of the whole document:
+ *
+ * * @ref bscn_begin_sub / @ref bscn_end_sub delimit a span with the cursor.
+ * * @ref bscn_make_at pairs a view with a previously captured position.
+ *
+ * Example:
+ *
+ * @snippet samples/bscn.c bscn_kv
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifndef BSCN_API
+#define BSCN_API
+#endif
+
+/*! Customizable index/length type. Signed by default. */
+#ifndef BSCN_INDEX_TYPE
+#define BSCN_INDEX_TYPE int
+#endif
+
+#ifndef BSCN_ASSERT
+#include <assert.h>
+#define BSCN_ASSERT(cond) assert(cond)
+#endif
+
+typedef BSCN_INDEX_TYPE bscn_index_t;
+
+/*! Non-owning view into the scanner's input. Not NUL-terminated. */
+typedef struct {
+	const char* chars;
+	bscn_index_t len;
+} bscn_str_t;
+
+/*! Make a view from a string literal */
+#define BSCN_STR(LIT) \
+	((bscn_str_t){ .chars = LIT, .len = (bscn_index_t)(sizeof(LIT) - 1) })
+
+/*! Character class predicate */
+typedef bool (*bscn_char_predicate_t)(char ch);
+
+/*!
+ * @brief Position of the cursor.
+ *
+ * Line and column are 1-based.
+ * The column is counted in bytes: tabs count as one and UTF-8 sequences count
+ * as their byte length.
+ */
+typedef struct {
+	/*! 0-based byte offset into the input */
+	bscn_index_t offset;
+	/*! 1-based line number */
+	bscn_index_t line;
+	/*! 1-based byte column within the line */
+	bscn_index_t column;
+} bscn_pos_t;
+
+/*! Scanner state. Initialize with @ref bscn_make. */
+typedef struct {
+	bscn_str_t input;
+
+	// Private, do not initialize
+	bscn_index_t bscn__cursor;
+	bscn_index_t bscn__line;
+	bscn_index_t bscn__line_start;
+	bscn_pos_t bscn__base;
+} bscn_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Construction
+
+/*! Create a scanner over an input view */
+BSCN_API bscn_t
+bscn_make(bscn_str_t input);
+
+/*! Create a scanner over a NUL-terminated string */
+BSCN_API bscn_t
+bscn_make_cstr(const char* cstr);
+
+/**
+ * @brief Create a scanner whose reported positions start at `base`.
+ *
+ * Use this when `view` was cut out of a larger document and its original
+ * position is known.
+ * This is the analogue of the C preprocessor's `#line` directive.
+ *
+ * A common pattern is to pair it with a view-returning accept:
+ *
+ * @snippet samples/bscn.c bscn_kv
+ *
+ * @param view The input of the new scanner.
+ * @param base The position of the first byte of `view` in the larger document.
+ */
+BSCN_API bscn_t
+bscn_make_at(bscn_str_t view, bscn_pos_t base);
+
+/**
+ * @brief Mark the start of a sub-scanner at the current cursor.
+ *
+ * Pair with @ref bscn_end_sub.
+ * The returned position can also be used for error reporting.
+ */
+BSCN_API bscn_pos_t
+bscn_begin_sub(const bscn_t* scn);
+
+/**
+ * @brief Create a sub-scanner over everything consumed since `begin`.
+ *
+ * The sub-scanner reports positions in the parent's coordinate system.
+ * Its input is the span from `begin` up to (but not including) the parent's
+ * cursor, so end it *before* accepting a closing delimiter:
+ *
+ * @snippet samples/bscn.c bscn_sub
+ *
+ * The parent and the sub-scanner are independent after this call.
+ *
+ * @param scn The parent scanner.
+ * @param begin A position previously returned by @ref bscn_begin_sub
+ *   on the same scanner.
+ */
+BSCN_API bscn_t
+bscn_end_sub(const bscn_t* scn, bscn_pos_t begin);
+
+// State
+
+/*! Whether the cursor is at the end of input */
+BSCN_API bool
+bscn_is_done(const bscn_t* scn);
+
+/*! Current position of the cursor */
+BSCN_API bscn_pos_t
+bscn_pos(const bscn_t* scn);
+
+/*! Everything from the cursor to the end of input */
+BSCN_API bscn_str_t
+bscn_remaining(const bscn_t* scn);
+
+/**
+ * @brief Move the cursor to a previously captured position.
+ *
+ * `pos` must have been returned by @ref bscn_pos or @ref bscn_begin_sub on
+ * this same scanner.
+ */
+BSCN_API void
+bscn_seek(bscn_t* scn, bscn_pos_t pos);
+
+/*! Move the cursor back to the start of input */
+BSCN_API void
+bscn_reset(bscn_t* scn);
+
+// Matching
+//
+// All matchers return a view of the matched text.
+// accept* moves the cursor past the match; peek* never moves it.
+// On failure, an empty view anchored at the cursor is returned and the cursor
+// does not move.
+
+/*! Consume a single expected character */
+BSCN_API bscn_str_t
+bscn_accept_char(bscn_t* scn, char ch);
+
+/*! Consume an exact sequence (all or nothing) */
+BSCN_API bscn_str_t
+bscn_accept_str(bscn_t* scn, bscn_str_t str);
+
+/*! Consume a (possibly empty) run of characters matching a predicate */
+BSCN_API bscn_str_t
+bscn_accept_while(bscn_t* scn, bscn_char_predicate_t pred);
+
+/**
+ * @brief Consume up to (not including) the first occurrence of a character.
+ *
+ * If the character never occurs, the rest of the input is consumed.
+ */
+BSCN_API bscn_str_t
+bscn_accept_until_char(bscn_t* scn, char ch);
+
+/**
+ * @brief Consume up to (not including) the first occurrence of a sequence.
+ *
+ * If the sequence never occurs, the rest of the input is consumed.
+ */
+BSCN_API bscn_str_t
+bscn_accept_until_str(bscn_t* scn, bscn_str_t str);
+
+/**
+ * @brief Consume up to (not including) the first character matching a predicate.
+ *
+ * If no character matches, the rest of the input is consumed.
+ */
+BSCN_API bscn_str_t
+bscn_accept_until_pred(bscn_t* scn, bscn_char_predicate_t pred);
+
+/*! Non-moving counterpart of @ref bscn_accept_char */
+BSCN_API bscn_str_t
+bscn_peek_char(const bscn_t* scn, char ch);
+
+/*! Non-moving counterpart of @ref bscn_accept_str */
+BSCN_API bscn_str_t
+bscn_peek_str(const bscn_t* scn, bscn_str_t str);
+
+/*! Non-moving counterpart of @ref bscn_accept_while */
+BSCN_API bscn_str_t
+bscn_peek_while(const bscn_t* scn, bscn_char_predicate_t pred);
+
+/*! Consume one line terminator: `\r\n` or `\n`. Empty view if not at one. */
+BSCN_API bscn_str_t
+bscn_accept_new_line(bscn_t* scn);
+
+/**
+ * @brief Consume and return the next line, excluding the terminator.
+ *
+ * Both `\n` and `\r\n` are handled.
+ * A blank line is a valid (empty) result, so loop on `!bscn_is_done(scn)`,
+ * not on emptiness:
+ *
+ * @snippet samples/bscn.c bscn_line_loop
+ */
+BSCN_API bscn_str_t
+bscn_next_line(bscn_t* scn);
+
+// Character classes
+
+/*! Whether `ch` is one of: space, `\t`, `\r`, `\n`, `\v`, `\f` */
+BSCN_API bool
+bscn_space(char ch);
+
+/*! Negation of @ref bscn_space */
+BSCN_API bool
+bscn_non_space(char ch);
+
+/*! Whether `ch` is `\r` or `\n` */
+BSCN_API bool
+bscn_new_line(char ch);
+
+/*! Whether `ch` is a decimal digit */
+BSCN_API bool
+bscn_digit(char ch);
+
+/*! Whether `ch` is in `[A-Za-z0-9_]` */
+BSCN_API bool
+bscn_identifier(char ch);
+
+// View helpers
+
+/*! Whether a view is empty. Both "no match" and "matched nothing" are empty. */
+BSCN_API bool
+bscn_str_is_empty(bscn_str_t str);
+
+/*! Content equality */
+BSCN_API bool
+bscn_str_eq(bscn_str_t lhs, bscn_str_t rhs);
+
+/*! Trim characters matching a predicate from both ends */
+BSCN_API bscn_str_t
+bscn_str_trim(bscn_str_t str, bscn_char_predicate_t pred);
+
+// Adapters for the generic macros, do not call directly
+
+BSCN_API bscn_str_t
+bscn__accept_lit(bscn_t* scn, const char* lit);
+
+BSCN_API bscn_str_t
+bscn__accept_until_lit(bscn_t* scn, const char* lit);
+
+BSCN_API bscn_str_t
+bscn__peek_lit(const bscn_t* scn, const char* lit);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @brief Generic version of the `bscn_accept_*` functions.
+ *
+ * Dispatch on the second argument:
+ *
+ * * `bscn_accept(scn, ';')` calls @ref bscn_accept_char.
+ * * `bscn_accept(scn, "://")` calls @ref bscn_accept_str.
+ * * `bscn_accept(scn, bscn_space)` calls @ref bscn_accept_while.
+ *
+ * @hideinitializer
+ */
+#define bscn_accept(SCN, WHAT) \
+	_Generic((WHAT), \
+		char: bscn_accept_char, \
+		int: bscn_accept_char, \
+		char*: bscn__accept_lit, \
+		const char*: bscn__accept_lit, \
+		bscn_str_t: bscn_accept_str, \
+		bscn_char_predicate_t: bscn_accept_while \
+	)((SCN), (WHAT))
+
+/**
+ * @brief Generic version of the `bscn_accept_until_*` functions.
+ *
+ * Dispatch on the second argument like @ref bscn_accept.
+ *
+ * @hideinitializer
+ */
+#define bscn_accept_until(SCN, WHAT) \
+	_Generic((WHAT), \
+		char: bscn_accept_until_char, \
+		int: bscn_accept_until_char, \
+		char*: bscn__accept_until_lit, \
+		const char*: bscn__accept_until_lit, \
+		bscn_str_t: bscn_accept_until_str, \
+		bscn_char_predicate_t: bscn_accept_until_pred \
+	)((SCN), (WHAT))
+
+/**
+ * @brief Generic version of the `bscn_peek_*` functions.
+ *
+ * Dispatch on the second argument like @ref bscn_accept.
+ *
+ * @hideinitializer
+ */
+#define bscn_peek(SCN, WHAT) \
+	_Generic((WHAT), \
+		char: bscn_peek_char, \
+		int: bscn_peek_char, \
+		char*: bscn__peek_lit, \
+		const char*: bscn__peek_lit, \
+		bscn_str_t: bscn_peek_str, \
+		bscn_char_predicate_t: bscn_peek_while \
+	)((SCN), (WHAT))
+
+#endif
+
+#if defined(BLIB_IMPLEMENTATION) && !defined(BSCN_IMPLEMENTATION)
+#define BSCN_IMPLEMENTATION
+#endif
+
+#ifdef BSCN_IMPLEMENTATION
+
+#include <string.h>
+
+static bscn_str_t
+bscn__empty(const bscn_t* scn) {
+	return (bscn_str_t){
+		.chars = scn->input.chars + scn->bscn__cursor,
+		.len = 0,
+	};
+}
+
+// The only place that moves the cursor forward.
+// It maintains line tracking by counting newlines in the consumed span.
+static bscn_str_t
+bscn__advance(bscn_t* scn, bscn_index_t len) {
+	bscn_str_t view = {
+		.chars = scn->input.chars + scn->bscn__cursor,
+		.len = len,
+	};
+
+	for (bscn_index_t i = 0; i < len; ++i) {
+		if (view.chars[i] == '\n') {
+			scn->bscn__line += 1;
+			scn->bscn__line_start = scn->bscn__cursor + i + 1;
+		}
+	}
+	scn->bscn__cursor += len;
+
+	return view;
+}
+
+static bscn_str_t
+bscn__cstr(const char* cstr) {
+	size_t len = cstr != NULL ? strlen(cstr) : 0;
+	bscn_index_t ilen = (bscn_index_t)len;
+	BSCN_ASSERT(ilen >= 0 && (size_t)ilen == len && "Input too large for bscn_index_t");
+	return (bscn_str_t){ .chars = cstr, .len = ilen };
+}
+
+bscn_t
+bscn_make(bscn_str_t input) {
+	return bscn_make_at(input, (bscn_pos_t){ .offset = 0, .line = 1, .column = 1 });
+}
+
+bscn_t
+bscn_make_cstr(const char* cstr) {
+	return bscn_make(bscn__cstr(cstr));
+}
+
+bscn_t
+bscn_make_at(bscn_str_t view, bscn_pos_t base) {
+	BSCN_ASSERT(view.len >= 0);
+	BSCN_ASSERT(base.line >= 1 && base.column >= 1);
+	return (bscn_t){
+		.input = view,
+		.bscn__cursor = 0,
+		.bscn__line = 1,
+		.bscn__line_start = 0,
+		.bscn__base = base,
+	};
+}
+
+bscn_pos_t
+bscn_begin_sub(const bscn_t* scn) {
+	return bscn_pos(scn);
+}
+
+bscn_t
+bscn_end_sub(const bscn_t* scn, bscn_pos_t begin) {
+	bscn_index_t begin_cursor = begin.offset - scn->bscn__base.offset;
+	BSCN_ASSERT(0 <= begin_cursor && begin_cursor <= scn->bscn__cursor);
+
+	bscn_str_t view = {
+		.chars = scn->input.chars + begin_cursor,
+		.len = scn->bscn__cursor - begin_cursor,
+	};
+	return bscn_make_at(view, begin);
+}
+
+bool
+bscn_is_done(const bscn_t* scn) {
+	return scn->bscn__cursor >= scn->input.len;
+}
+
+bscn_pos_t
+bscn_pos(const bscn_t* scn) {
+	bscn_index_t local_line = scn->bscn__line;
+	bscn_index_t local_column = scn->bscn__cursor - scn->bscn__line_start + 1;
+	bscn_pos_t base = scn->bscn__base;
+
+	return (bscn_pos_t){
+		.offset = base.offset + scn->bscn__cursor,
+		.line = base.line + (local_line - 1),
+		// Only the first line of the view is offset by where the view began
+		.column = local_line == 1 ? base.column + (local_column - 1) : local_column,
+	};
+}
+
+bscn_str_t
+bscn_remaining(const bscn_t* scn) {
+	return (bscn_str_t){
+		.chars = scn->input.chars + scn->bscn__cursor,
+		.len = scn->input.len - scn->bscn__cursor,
+	};
+}
+
+void
+bscn_seek(bscn_t* scn, bscn_pos_t pos) {
+	bscn_pos_t base = scn->bscn__base;
+
+	bscn_index_t cursor = pos.offset - base.offset;
+	BSCN_ASSERT(0 <= cursor && cursor <= scn->input.len);
+
+	bscn_index_t local_line = pos.line - base.line + 1;
+	BSCN_ASSERT(local_line >= 1);
+
+	bscn_index_t local_column = local_line == 1
+		? pos.column - base.column + 1
+		: pos.column;
+	BSCN_ASSERT(1 <= local_column && local_column <= cursor + 1);
+
+	scn->bscn__cursor = cursor;
+	scn->bscn__line = local_line;
+	scn->bscn__line_start = cursor - (local_column - 1);
+}
+
+void
+bscn_reset(bscn_t* scn) {
+	scn->bscn__cursor = 0;
+	scn->bscn__line = 1;
+	scn->bscn__line_start = 0;
+}
+
+bscn_str_t
+bscn_accept_char(bscn_t* scn, char ch) {
+	if (!bscn_is_done(scn) && scn->input.chars[scn->bscn__cursor] == ch) {
+		return bscn__advance(scn, 1);
+	} else {
+		return bscn__empty(scn);
+	}
+}
+
+bscn_str_t
+bscn_accept_str(bscn_t* scn, bscn_str_t str) {
+	if (bscn_str_is_empty(bscn_peek_str(scn, str))) {
+		return bscn__empty(scn);
+	} else {
+		return bscn__advance(scn, str.len);
+	}
+}
+
+bscn_str_t
+bscn_accept_while(bscn_t* scn, bscn_char_predicate_t pred) {
+	bscn_index_t i = scn->bscn__cursor;
+	while (i < scn->input.len && pred(scn->input.chars[i])) { ++i; }
+	return bscn__advance(scn, i - scn->bscn__cursor);
+}
+
+bscn_str_t
+bscn_accept_until_char(bscn_t* scn, char ch) {
+	bscn_index_t i = scn->bscn__cursor;
+	while (i < scn->input.len && scn->input.chars[i] != ch) { ++i; }
+	return bscn__advance(scn, i - scn->bscn__cursor);
+}
+
+bscn_str_t
+bscn_accept_until_str(bscn_t* scn, bscn_str_t str) {
+	if (str.len <= 0) { return bscn__empty(scn); }
+
+	for (bscn_index_t i = scn->bscn__cursor; i + str.len <= scn->input.len; ++i) {
+		if (memcmp(scn->input.chars + i, str.chars, (size_t)str.len) == 0) {
+			return bscn__advance(scn, i - scn->bscn__cursor);
+		}
+	}
+
+	return bscn__advance(scn, scn->input.len - scn->bscn__cursor);
+}
+
+bscn_str_t
+bscn_accept_until_pred(bscn_t* scn, bscn_char_predicate_t pred) {
+	bscn_index_t i = scn->bscn__cursor;
+	while (i < scn->input.len && !pred(scn->input.chars[i])) { ++i; }
+	return bscn__advance(scn, i - scn->bscn__cursor);
+}
+
+bscn_str_t
+bscn_peek_char(const bscn_t* scn, char ch) {
+	if (!bscn_is_done(scn) && scn->input.chars[scn->bscn__cursor] == ch) {
+		return (bscn_str_t){
+			.chars = scn->input.chars + scn->bscn__cursor,
+			.len = 1,
+		};
+	} else {
+		return bscn__empty(scn);
+	}
+}
+
+bscn_str_t
+bscn_peek_str(const bscn_t* scn, bscn_str_t str) {
+	if (
+		str.len > 0
+		&& str.len <= scn->input.len - scn->bscn__cursor
+		&& memcmp(scn->input.chars + scn->bscn__cursor, str.chars, (size_t)str.len) == 0
+	) {
+		return (bscn_str_t){
+			.chars = scn->input.chars + scn->bscn__cursor,
+			.len = str.len,
+		};
+	} else {
+		return bscn__empty(scn);
+	}
+}
+
+bscn_str_t
+bscn_peek_while(const bscn_t* scn, bscn_char_predicate_t pred) {
+	bscn_index_t i = scn->bscn__cursor;
+	while (i < scn->input.len && pred(scn->input.chars[i])) { ++i; }
+	return (bscn_str_t){
+		.chars = scn->input.chars + scn->bscn__cursor,
+		.len = i - scn->bscn__cursor,
+	};
+}
+
+bscn_str_t
+bscn_accept_new_line(bscn_t* scn) {
+	const char* cur = scn->input.chars + scn->bscn__cursor;
+	bscn_index_t remaining = scn->input.len - scn->bscn__cursor;
+
+	if (remaining >= 2 && cur[0] == '\r' && cur[1] == '\n') {
+		return bscn__advance(scn, 2);
+	} else if (remaining >= 1 && cur[0] == '\n') {
+		return bscn__advance(scn, 1);
+	} else {
+		return bscn__empty(scn);
+	}
+}
+
+bscn_str_t
+bscn_next_line(bscn_t* scn) {
+	const char* chars = scn->input.chars;
+	bscn_index_t begin = scn->bscn__cursor;
+
+	bscn_index_t i = begin;
+	while (i < scn->input.len && chars[i] != '\n') { ++i; }
+
+	bscn_index_t content_end = i;
+	if (content_end > begin && chars[content_end - 1] == '\r') { --content_end; }
+
+	// Consume the terminator but exclude it from the view
+	bscn_index_t consumed = i < scn->input.len ? i + 1 - begin : i - begin;
+	bscn__advance(scn, consumed);
+
+	return (bscn_str_t){ .chars = chars + begin, .len = content_end - begin };
+}
+
+bool
+bscn_space(char ch) {
+	return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n' || ch == '\v' || ch == '\f';
+}
+
+bool
+bscn_non_space(char ch) {
+	return !bscn_space(ch);
+}
+
+bool
+bscn_new_line(char ch) {
+	return ch == '\r' || ch == '\n';
+}
+
+bool
+bscn_digit(char ch) {
+	return '0' <= ch && ch <= '9';
+}
+
+bool
+bscn_identifier(char ch) {
+	return ('a' <= ch && ch <= 'z')
+		|| ('A' <= ch && ch <= 'Z')
+		|| bscn_digit(ch)
+		|| ch == '_';
+}
+
+bool
+bscn_str_is_empty(bscn_str_t str) {
+	return str.len <= 0;
+}
+
+bool
+bscn_str_eq(bscn_str_t lhs, bscn_str_t rhs) {
+	if (lhs.len != rhs.len) { return false; }
+	if (lhs.len <= 0) { return true; }
+	return memcmp(lhs.chars, rhs.chars, (size_t)lhs.len) == 0;
+}
+
+bscn_str_t
+bscn_str_trim(bscn_str_t str, bscn_char_predicate_t pred) {
+	bscn_index_t begin = 0;
+	bscn_index_t end = str.len;
+	while (begin < end && pred(str.chars[begin])) { ++begin; }
+	while (end > begin && pred(str.chars[end - 1])) { --end; }
+	return (bscn_str_t){ .chars = str.chars + begin, .len = end - begin };
+}
+
+bscn_str_t
+bscn__accept_lit(bscn_t* scn, const char* lit) {
+	return bscn_accept_str(scn, bscn__cstr(lit));
+}
+
+bscn_str_t
+bscn__accept_until_lit(bscn_t* scn, const char* lit) {
+	return bscn_accept_until_str(scn, bscn__cstr(lit));
+}
+
+bscn_str_t
+bscn__peek_lit(const bscn_t* scn, const char* lit) {
+	return bscn_peek_str(scn, bscn__cstr(lit));
+}
+
+#endif

--- a/mainpage.md
+++ b/mainpage.md
@@ -11,6 +11,7 @@ Collection of miscellaneous single-header libraries.
 |@ref bserial.h|Serialization|
 |@ref bspscq.h|Single producer single consumer queue|
 |@ref bsv.h|Binary serialization with versioning|
+|@ref bscn.h|Text scanner for hand-written parsers|
 |@ref bstacktrace.h|Portable stacktrace with source mapping|
 |@ref bcrash_handler.h|Crash handler|
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -59,9 +59,10 @@ workspace "libs"
 
   filter { "action:vs*" }
     buildoptions {
-      "/std:c11",
+      "/std:clatest",
       "/experimental:c11atomics",
     }
+    defines { "_CRT_SECURE_NO_WARNINGS" }
     disablewarnings {
       "4100",
       "4200",
@@ -69,6 +70,7 @@ workspace "libs"
       "4459",
       "4324",
       "4116",
+      "4189", -- Too many misdiagnostics
     }
 
   debugdir "bin/%{cfg.buildcfg}"
@@ -114,7 +116,3 @@ project "tests"
     filter "configurations:Release"
       defines { "NDEBUG" }
       optimize "On"
-
-    filter "toolset:msc*"
-      defines { "_CRT_SECURE_NO_WARNINGS" }
-      buildoptions { "/std:clatest" }

--- a/premake5.lua
+++ b/premake5.lua
@@ -100,6 +100,8 @@ project "tests"
       "tests/bent/*.c",
       "tests/bsv/*.h",
       "tests/bsv/*.c",
+      "tests/bscn/*.h",
+      "tests/bscn/*.c",
       "tests/bco/*.h",
       "tests/bco/*.c",
       "tests/bstacktrace/*.c",

--- a/samples/bscn.c
+++ b/samples/bscn.c
@@ -1,0 +1,100 @@
+#include <stdio.h>
+
+#define BLIB_IMPLEMENTATION
+#include "../bscn.h"
+
+// Parse a document with an INI-like front matter followed by a free-form body:
+//
+//   ---
+//   name = water
+//   tint = deep blue
+//   ---
+//   The body follows the front matter.
+//
+// Positions reported from within the front matter sub-scanner are positions
+// in the whole document, not in the extracted block.
+
+#define PRISTR(STR) (int)(STR).len, (STR).chars
+
+static void
+parse_front_matter(bscn_t frontmatter) {
+	// Bind a sub-scanner to each line so that a malformed line cannot be
+	// parsed beyond its end
+	//!                                                                     [bscn_kv]
+	while (!bscn_is_done(&frontmatter)) {
+		bscn_pos_t line_pos = bscn_pos(&frontmatter);
+		bscn_t line = bscn_make_at(bscn_next_line(&frontmatter), line_pos);
+
+		bscn_accept(&line, bscn_space);
+		if (bscn_is_done(&line)) { continue; }  // Blank line
+		if (!bscn_str_is_empty(bscn_accept(&line, ';'))) { continue; }  // Comment
+
+		bscn_str_t key = bscn_accept(&line, bscn_identifier);
+		bscn_accept(&line, bscn_space);
+		if (bscn_str_is_empty(bscn_accept(&line, '='))) {
+			// The error is reported in document coordinates
+			bscn_pos_t error_pos = bscn_pos(&line);
+			printf(
+				"%d:%d: expected `key = value`\n",
+				(int)error_pos.line, (int)error_pos.column
+			);
+			continue;
+		}
+		bscn_str_t value = bscn_str_trim(bscn_remaining(&line), bscn_space);
+
+		printf("%.*s => %.*s\n", PRISTR(key), PRISTR(value));
+	}
+	//!                                                                     [bscn_kv]
+}
+
+static void
+parse_document(bscn_str_t document) {
+	bscn_t scn = bscn_make(document);
+
+	// Extract the front matter between the "---" fences.
+	// bscn_end_sub spans everything consumed since bscn_begin_sub, so the
+	// block is ended before the closing fence is accepted.
+	//!                                                                     [bscn_sub]
+	bscn_accept(&scn, "---");
+	bscn_accept_new_line(&scn);
+
+	bscn_pos_t front_matter_begin = bscn_begin_sub(&scn);
+	bscn_accept_until(&scn, "\n---");
+	bscn_accept_new_line(&scn);
+	bscn_t frontmatter = bscn_end_sub(&scn, front_matter_begin);
+
+	bscn_accept(&scn, "---");
+	bscn_accept_new_line(&scn);
+	//!                                                                     [bscn_sub]
+
+	parse_front_matter(frontmatter);
+
+	// Print the body with document line numbers
+	//!                                                                     [bscn_line_loop]
+	while (!bscn_is_done(&scn)) {
+		bscn_pos_t pos = bscn_pos(&scn);
+		bscn_str_t body_line = bscn_next_line(&scn);
+		printf("%3d| %.*s\n", (int)pos.line, PRISTR(body_line));
+	}
+	//!                                                                     [bscn_line_loop]
+}
+
+int
+main(int argc, const char* argv[]) {
+	(void)argc;
+	(void)argv;
+
+	parse_document(BSCN_STR(
+		"---\n"
+		"; a comment\n"
+		"name = water\n"
+		"tint = deep blue\n"
+		"oops\n"
+		"speed = 3\n"
+		"---\n"
+		"The body follows the front matter.\n"
+		"It spans multiple lines.\n"
+	));
+
+	return 0;
+}

--- a/tests/bscn/basic.c
+++ b/tests/bscn/basic.c
@@ -1,0 +1,131 @@
+#include "../../bscn.h"
+#include "../../btest.h"
+
+static btest_suite_t basic = {
+	.name = "bscn/basic",
+};
+
+BTEST(basic, accept_char) {
+	bscn_t scn = bscn_make_cstr("a=b");
+
+	BTEST_EXPECT_EQUAL("%d", (int)bscn_accept_char(&scn, 'a').len, 1);
+
+	// A failed match returns an empty view at the cursor and does not move it
+	bscn_str_t miss = bscn_accept_char(&scn, 'x');
+	BTEST_EXPECT(bscn_str_is_empty(miss));
+	BTEST_EXPECT(miss.chars == scn.input.chars + 1);
+	BTEST_EXPECT_EQUAL("%d", (int)bscn_pos(&scn).offset, 1);
+
+	BTEST_EXPECT_EQUAL("%d", (int)bscn_accept_char(&scn, '=').len, 1);
+	BTEST_EXPECT_EQUAL("%d", (int)bscn_accept_char(&scn, 'b').len, 1);
+	BTEST_EXPECT(bscn_is_done(&scn));
+
+	// Accept at the end of input
+	BTEST_EXPECT(bscn_str_is_empty(bscn_accept_char(&scn, 'b')));
+}
+
+BTEST(basic, accept_str) {
+	bscn_t scn = bscn_make_cstr("http://example.com");
+
+	BTEST_EXPECT(bscn_str_eq(bscn_accept_str(&scn, BSCN_STR("http")), BSCN_STR("http")));
+
+	// All or nothing
+	BTEST_EXPECT(bscn_str_is_empty(bscn_accept_str(&scn, BSCN_STR(":/x"))));
+	BTEST_EXPECT_EQUAL("%d", (int)bscn_pos(&scn).offset, 4);
+
+	BTEST_EXPECT(!bscn_str_is_empty(bscn_accept_str(&scn, BSCN_STR("://"))));
+	BTEST_EXPECT(bscn_str_eq(bscn_remaining(&scn), BSCN_STR("example.com")));
+}
+
+BTEST(basic, accept_while) {
+	bscn_t scn = bscn_make_cstr("  hello_1 world");
+
+	bscn_str_t spaces = bscn_accept_while(&scn, bscn_space);
+	BTEST_EXPECT_EQUAL("%d", (int)spaces.len, 2);
+
+	bscn_str_t ident = bscn_accept_while(&scn, bscn_identifier);
+	BTEST_EXPECT(bscn_str_eq(ident, BSCN_STR("hello_1")));
+
+	// Matching nothing is an empty view, cursor stays put
+	BTEST_EXPECT(bscn_str_is_empty(bscn_accept_while(&scn, bscn_identifier)));
+	BTEST_EXPECT_EQUAL("%d", (int)bscn_pos(&scn).offset, 9);
+}
+
+BTEST(basic, accept_until) {
+	bscn_t scn = bscn_make_cstr("key]=value");
+
+	// The delimiter itself is not consumed
+	bscn_str_t key = bscn_accept_until_char(&scn, ']');
+	BTEST_EXPECT(bscn_str_eq(key, BSCN_STR("key")));
+	BTEST_EXPECT_EQUAL("%d", (int)bscn_accept_char(&scn, ']').len, 1);
+
+	// A missing delimiter consumes the rest of the input
+	bscn_str_t rest = bscn_accept_until_char(&scn, ']');
+	BTEST_EXPECT(bscn_str_eq(rest, BSCN_STR("=value")));
+	BTEST_EXPECT(bscn_is_done(&scn));
+}
+
+BTEST(basic, accept_until_str) {
+	bscn_t scn = bscn_make_cstr("http://example.com");
+
+	bscn_str_t scheme = bscn_accept_until_str(&scn, BSCN_STR("://"));
+	BTEST_EXPECT(bscn_str_eq(scheme, BSCN_STR("http")));
+	BTEST_EXPECT(!bscn_str_is_empty(bscn_accept_str(&scn, BSCN_STR("://"))));
+
+	bscn_str_t rest = bscn_accept_until_str(&scn, BSCN_STR("://"));
+	BTEST_EXPECT(bscn_str_eq(rest, BSCN_STR("example.com")));
+	BTEST_EXPECT(bscn_is_done(&scn));
+}
+
+BTEST(basic, accept_until_pred) {
+	bscn_t scn = bscn_make_cstr("value; comment");
+
+	bscn_str_t value = bscn_accept_until_pred(&scn, bscn_space);
+	BTEST_EXPECT(bscn_str_eq(value, BSCN_STR("value;")));
+}
+
+BTEST(basic, peek) {
+	bscn_t scn = bscn_make_cstr("abc");
+
+	// Peek never moves the cursor
+	BTEST_EXPECT_EQUAL("%d", (int)bscn_peek_char(&scn, 'a').len, 1);
+	BTEST_EXPECT(bscn_str_is_empty(bscn_peek_char(&scn, 'b')));
+	BTEST_EXPECT_EQUAL("%d", (int)bscn_peek_str(&scn, BSCN_STR("ab")).len, 2);
+	BTEST_EXPECT(bscn_str_is_empty(bscn_peek_str(&scn, BSCN_STR("abcd"))));
+	BTEST_EXPECT_EQUAL("%d", (int)bscn_peek_while(&scn, bscn_identifier).len, 3);
+	BTEST_EXPECT_EQUAL("%d", (int)bscn_pos(&scn).offset, 0);
+}
+
+BTEST(basic, generic_macros) {
+	bscn_t scn = bscn_make_cstr("[section] ; note");
+
+	BTEST_EXPECT(!bscn_str_is_empty(bscn_accept(&scn, '[')));
+	BTEST_EXPECT(bscn_str_eq(bscn_accept(&scn, bscn_identifier), BSCN_STR("section")));
+	BTEST_EXPECT(!bscn_str_is_empty(bscn_accept(&scn, "]")));
+	BTEST_EXPECT(!bscn_str_is_empty(bscn_accept(&scn, BSCN_STR(" "))));
+	BTEST_EXPECT(!bscn_str_is_empty(bscn_peek(&scn, ';')));
+	BTEST_EXPECT(bscn_str_eq(bscn_accept_until(&scn, "note"), BSCN_STR("; ")));
+	BTEST_EXPECT(bscn_str_eq(bscn_accept_until(&scn, bscn_space), BSCN_STR("note")));
+}
+
+BTEST(basic, str_helpers) {
+	BTEST_EXPECT(bscn_str_is_empty(BSCN_STR("")));
+	BTEST_EXPECT(bscn_str_eq(BSCN_STR(""), BSCN_STR("")));
+	BTEST_EXPECT(!bscn_str_eq(BSCN_STR("ab"), BSCN_STR("abc")));
+	BTEST_EXPECT(!bscn_str_eq(BSCN_STR("ab"), BSCN_STR("ac")));
+
+	BTEST_EXPECT(bscn_str_eq(
+		bscn_str_trim(BSCN_STR("  hi \t "), bscn_space),
+		BSCN_STR("hi")
+	));
+	BTEST_EXPECT(bscn_str_is_empty(bscn_str_trim(BSCN_STR("   "), bscn_space)));
+}
+
+BTEST(basic, empty_input) {
+	bscn_t scn = bscn_make(BSCN_STR(""));
+
+	BTEST_EXPECT(bscn_is_done(&scn));
+	BTEST_EXPECT(bscn_str_is_empty(bscn_accept_while(&scn, bscn_space)));
+	BTEST_EXPECT(bscn_str_is_empty(bscn_next_line(&scn)));
+	BTEST_EXPECT(bscn_str_is_empty(bscn_remaining(&scn)));
+}

--- a/tests/bscn/pos.c
+++ b/tests/bscn/pos.c
@@ -1,0 +1,117 @@
+#include "../../bscn.h"
+#include "../../btest.h"
+
+static btest_suite_t pos = {
+	.name = "bscn/pos",
+};
+
+static void
+expect_pos(bscn_pos_t actual, bscn_index_t offset, bscn_index_t line, bscn_index_t column) {
+	BTEST_EXPECT_EQUAL("%d", (int)actual.offset, (int)offset);
+	BTEST_EXPECT_EQUAL("%d", (int)actual.line, (int)line);
+	BTEST_EXPECT_EQUAL("%d", (int)actual.column, (int)column);
+}
+
+BTEST(pos, tracking) {
+	bscn_t scn = bscn_make_cstr("ab\ncd");
+
+	expect_pos(bscn_pos(&scn), 0, 1, 1);
+
+	bscn_accept_until_char(&scn, '\n');
+	expect_pos(bscn_pos(&scn), 2, 1, 3);
+
+	bscn_accept_new_line(&scn);
+	expect_pos(bscn_pos(&scn), 3, 2, 1);
+
+	bscn_accept_str(&scn, BSCN_STR("cd"));
+	expect_pos(bscn_pos(&scn), 5, 2, 3);
+}
+
+BTEST(pos, tracking_bulk) {
+	// A single accept spanning multiple lines still tracks correctly
+	bscn_t scn = bscn_make_cstr("one\ntwo\nthree");
+
+	bscn_accept_while(&scn, bscn_non_space);
+	bscn_accept_while(&scn, bscn_space);
+	bscn_accept_until_str(&scn, BSCN_STR("ree"));
+	expect_pos(bscn_pos(&scn), 10, 3, 3);
+}
+
+BTEST(pos, next_line) {
+	bscn_t scn = bscn_make_cstr("one\n\nthree");
+
+	BTEST_EXPECT(bscn_str_eq(bscn_next_line(&scn), BSCN_STR("one")));
+	expect_pos(bscn_pos(&scn), 4, 2, 1);
+
+	// A blank line is a valid, empty result
+	BTEST_EXPECT(bscn_str_is_empty(bscn_next_line(&scn)));
+	BTEST_EXPECT(!bscn_is_done(&scn));
+
+	// The last line does not need a terminator
+	BTEST_EXPECT(bscn_str_eq(bscn_next_line(&scn), BSCN_STR("three")));
+	BTEST_EXPECT(bscn_is_done(&scn));
+}
+
+BTEST(pos, crlf) {
+	bscn_t scn = bscn_make_cstr("one\r\ntwo\nthree\r\n");
+
+	// The `\r` is stripped from the view along with the terminator
+	BTEST_EXPECT(bscn_str_eq(bscn_next_line(&scn), BSCN_STR("one")));
+	expect_pos(bscn_pos(&scn), 5, 2, 1);
+
+	BTEST_EXPECT(bscn_str_eq(bscn_next_line(&scn), BSCN_STR("two")));
+	BTEST_EXPECT(bscn_str_eq(bscn_next_line(&scn), BSCN_STR("three")));
+	BTEST_EXPECT(bscn_is_done(&scn));
+	expect_pos(bscn_pos(&scn), 16, 4, 1);
+}
+
+BTEST(pos, accept_new_line) {
+	bscn_t scn = bscn_make_cstr("\r\n\nx\r");
+
+	BTEST_EXPECT_EQUAL("%d", (int)bscn_accept_new_line(&scn).len, 2);
+	expect_pos(bscn_pos(&scn), 2, 2, 1);
+
+	BTEST_EXPECT_EQUAL("%d", (int)bscn_accept_new_line(&scn).len, 1);
+	expect_pos(bscn_pos(&scn), 3, 3, 1);
+
+	// Not at a terminator
+	BTEST_EXPECT(bscn_str_is_empty(bscn_accept_new_line(&scn)));
+	bscn_accept_char(&scn, 'x');
+
+	// A lone `\r` is not a terminator
+	BTEST_EXPECT(bscn_str_is_empty(bscn_accept_new_line(&scn)));
+}
+
+BTEST(pos, until_new_line) {
+	// The manual line splitting pattern, ending agnostic
+	bscn_t scn = bscn_make_cstr("one\r\ntwo\nthree");
+
+	BTEST_EXPECT(bscn_str_eq(bscn_accept_until(&scn, bscn_new_line), BSCN_STR("one")));
+	BTEST_EXPECT(!bscn_str_is_empty(bscn_accept_new_line(&scn)));
+
+	BTEST_EXPECT(bscn_str_eq(bscn_accept_until(&scn, bscn_new_line), BSCN_STR("two")));
+	BTEST_EXPECT(!bscn_str_is_empty(bscn_accept_new_line(&scn)));
+
+	BTEST_EXPECT(bscn_str_eq(bscn_accept_until(&scn, bscn_new_line), BSCN_STR("three")));
+	BTEST_EXPECT(bscn_is_done(&scn));
+}
+
+BTEST(pos, seek) {
+	bscn_t scn = bscn_make_cstr("one\ntwo\nthree");
+
+	bscn_next_line(&scn);
+	bscn_pos_t saved = bscn_pos(&scn);
+
+	bscn_next_line(&scn);
+	bscn_accept_str(&scn, BSCN_STR("th"));
+	expect_pos(bscn_pos(&scn), 10, 3, 3);
+
+	// Seek backwards to a saved position
+	bscn_seek(&scn, saved);
+	expect_pos(bscn_pos(&scn), 4, 2, 1);
+	BTEST_EXPECT(bscn_str_eq(bscn_next_line(&scn), BSCN_STR("two")));
+
+	bscn_reset(&scn);
+	expect_pos(bscn_pos(&scn), 0, 1, 1);
+	BTEST_EXPECT(bscn_str_eq(bscn_next_line(&scn), BSCN_STR("one")));
+}

--- a/tests/bscn/shared.c
+++ b/tests/bscn/shared.c
@@ -1,0 +1,2 @@
+#define BLIB_IMPLEMENTATION
+#include "../../bscn.h"

--- a/tests/bscn/sub.c
+++ b/tests/bscn/sub.c
@@ -1,0 +1,128 @@
+#include "../../bscn.h"
+#include "../../btest.h"
+
+static btest_suite_t sub = {
+	.name = "bscn/sub",
+};
+
+static void
+expect_pos(bscn_pos_t actual, bscn_index_t offset, bscn_index_t line, bscn_index_t column) {
+	BTEST_EXPECT_EQUAL("%d", (int)actual.offset, (int)offset);
+	BTEST_EXPECT_EQUAL("%d", (int)actual.line, (int)line);
+	BTEST_EXPECT_EQUAL("%d", (int)actual.column, (int)column);
+}
+
+BTEST(sub, begin_end) {
+	bscn_t scn = bscn_make_cstr("head\nAA\nBB\ntail");
+
+	bscn_next_line(&scn);
+
+	bscn_pos_t begin = bscn_begin_sub(&scn);
+	bscn_accept_until_str(&scn, BSCN_STR("tail"));
+	bscn_t block = bscn_end_sub(&scn, begin);
+
+	BTEST_EXPECT(bscn_str_eq(block.input, BSCN_STR("AA\nBB\n")));
+	BTEST_EXPECT(bscn_str_eq(bscn_remaining(&scn), BSCN_STR("tail")));
+
+	// The sub-scanner reports positions in the parent's coordinates
+	expect_pos(bscn_pos(&block), 5, 2, 1);
+	BTEST_EXPECT(bscn_str_eq(bscn_next_line(&block), BSCN_STR("AA")));
+	expect_pos(bscn_pos(&block), 8, 3, 1);
+	bscn_accept_char(&block, 'B');
+	expect_pos(bscn_pos(&block), 9, 3, 2);
+
+	// The parent is unaffected
+	expect_pos(bscn_pos(&scn), 11, 4, 1);
+}
+
+BTEST(sub, empty) {
+	bscn_t scn = bscn_make_cstr("ab");
+	bscn_accept_char(&scn, 'a');
+
+	bscn_t block = bscn_end_sub(&scn, bscn_begin_sub(&scn));
+	BTEST_EXPECT(bscn_str_is_empty(block.input));
+	BTEST_EXPECT(bscn_is_done(&block));
+	expect_pos(bscn_pos(&block), 1, 1, 2);
+}
+
+BTEST(sub, make_at) {
+	// A view with a known origin in a larger document
+	bscn_t scn = bscn_make_at(
+		BSCN_STR("ab\ncd"),
+		(bscn_pos_t){ .offset = 100, .line = 10, .column = 5 }
+	);
+
+	expect_pos(bscn_pos(&scn), 100, 10, 5);
+
+	// The first line is offset by the base column
+	bscn_accept_str(&scn, BSCN_STR("ab"));
+	expect_pos(bscn_pos(&scn), 102, 10, 7);
+
+	// Later lines are not
+	bscn_accept_new_line(&scn);
+	expect_pos(bscn_pos(&scn), 103, 11, 1);
+	bscn_accept_str(&scn, BSCN_STR("cd"));
+	expect_pos(bscn_pos(&scn), 105, 11, 3);
+}
+
+BTEST(sub, make_at_line) {
+	// Line-bound sub-scanner: pair bscn_next_line with the position
+	// captured right before it
+	bscn_t scn = bscn_make_cstr("key = value\nnext");
+	bscn_pos_t line_pos = bscn_pos(&scn);
+	bscn_t line = bscn_make_at(bscn_next_line(&scn), line_pos);
+
+	bscn_str_t key = bscn_accept_while(&line, bscn_identifier);
+	BTEST_EXPECT(bscn_str_eq(key, BSCN_STR("key")));
+	bscn_accept_while(&line, bscn_space);
+	bscn_accept_char(&line, '=');
+	expect_pos(bscn_pos(&line), 5, 1, 6);
+
+	// The sub-scanner cannot run past its line
+	bscn_accept_until_char(&line, 'x');
+	BTEST_EXPECT(bscn_is_done(&line));
+	expect_pos(bscn_pos(&line), 11, 1, 12);
+}
+
+BTEST(sub, nested) {
+	bscn_t scn = bscn_make_cstr("1\n2 [deep]\n3");
+
+	bscn_next_line(&scn);
+
+	// Outer sub: the second line
+	bscn_pos_t outer_begin = bscn_begin_sub(&scn);
+	bscn_accept_until_pred(&scn, bscn_new_line);
+	bscn_t outer = bscn_end_sub(&scn, outer_begin);
+
+	// Inner sub: the bracketed part
+	bscn_accept_until_char(&outer, '[');
+	bscn_accept_char(&outer, '[');
+	bscn_pos_t inner_begin = bscn_begin_sub(&outer);
+	bscn_accept_until_char(&outer, ']');
+	bscn_t inner = bscn_end_sub(&outer, inner_begin);
+
+	BTEST_EXPECT(bscn_str_eq(inner.input, BSCN_STR("deep")));
+	expect_pos(bscn_pos(&inner), 5, 2, 4);
+	bscn_accept_while(&inner, bscn_identifier);
+	expect_pos(bscn_pos(&inner), 9, 2, 8);
+}
+
+BTEST(sub, seek_in_sub) {
+	// Seeking works with positions in parent coordinates
+	bscn_t scn = bscn_make_cstr("head [ab\ncd]");
+
+	bscn_accept_until_char(&scn, '[');
+	bscn_accept_char(&scn, '[');
+	bscn_pos_t begin = bscn_begin_sub(&scn);
+	bscn_accept_until_char(&scn, ']');
+	bscn_t block = bscn_end_sub(&scn, begin);
+
+	bscn_next_line(&block);
+	bscn_pos_t saved = bscn_pos(&block);
+	expect_pos(saved, 9, 2, 1);
+	bscn_accept_str(&block, BSCN_STR("cd"));
+
+	bscn_seek(&block, saved);
+	expect_pos(bscn_pos(&block), 9, 2, 1);
+	BTEST_EXPECT(bscn_str_eq(bscn_remaining(&block), BSCN_STR("cd")));
+}


### PR DESCRIPTION
A zero-copy text scanner for hand-written parsers, inspired by bx::Scanner (https://bkaradzic.github.io/posts/scanner/).