### PR TITLE
Revert "bco: Add check so that free variables will not be skipped (#13)"

### DIFF
--- a/bco.h
+++ b/bco.h
@@ -225,7 +225,6 @@
 #define bco_begin \
 	_Static_assert(bco__begin_declared == 0, "bco_begin can only be used once"); \
 	enum { bco__begin_declared = 1 }; \
-	bco__diag_push \
 	(void)bco__args; \
 	switch (bco__on_resume(bco__coro)) { \
 		case BCO__RELOCATE: bco__relocate(bco__coro, bco__yps, bco__yps_count); return; \
@@ -260,7 +259,6 @@
 		bco__cleanup: bco__on_terminate(bco__coro); \
 	} /* default */ \
 	} /* switch */ \
-	bco__diag_pop \
 	enum { bco__end_declared = 1 };
 
 /**
@@ -672,18 +670,6 @@ bco_reload_end(bco_t* coro);
 #else
 #define bco__begin_constant_cond
 #define bco__end_constant_cond
-#endif
-
-// Catch locals that should have been declared with bco_vars: their initialization
-// would be skipped when a resume jumps to a case label past them.
-#if defined(__GNUC__) || defined(__clang__)
-#define bco__diag_push \
-	_Pragma("GCC diagnostic push") \
-	_Pragma("GCC diagnostic error \"-Wjump-misses-init\"")
-#define bco__diag_pop _Pragma("GCC diagnostic pop")
-#else
-#define bco__diag_push
-#define bco__diag_pop
 #endif
 
 typedef void (*bco_fn_t)(bco_t* coro, void* args);

--- a/tests/bco/clone.c
+++ b/tests/bco/clone.c
@@ -52,10 +52,8 @@ bco_static(counter, int to) {
 	bco_vars(int i;)
 	bco_begin
 	for (bco_var(i) = 0; bco_var(i) < bco_arg(to); ++bco_var(i)) {
-		{  // Scoped so that it does not live across the yield below
-			const clone_env_t* env = bco_userdata;
-			trace("%s:%d:own=%d", env->name, bco_var(i), owns(env, &bco_var(i)));
-		}
+		const clone_env_t* env = bco_userdata;
+		trace("%s:%d:own=%d", env->name, bco_var(i), owns(env, &bco_var(i)));
 		bco_yield();
 	}
 	bco_end
@@ -127,10 +125,8 @@ bco_static(clone_sub, int rounds) {
 	bco_vars(int i;)
 	bco_begin
 	for (bco_var(i) = 0; bco_var(i) < bco_arg(rounds); ++bco_var(i)) {
-		{  // Scoped so that it does not live across the yield below
-			const clone_env_t* env = bco_userdata;
-			trace("%s:sub:%d:own=%d", env->name, bco_var(i), owns(env, &bco_var(i)));
-		}
+		const clone_env_t* env = bco_userdata;
+		trace("%s:sub:%d:own=%d", env->name, bco_var(i), owns(env, &bco_var(i)));
 		bco_yield();
 	}
 	bco_end


### PR DESCRIPTION
This reverts commit 7e75fbe2ce6cb66aeb8a571e254ddbaad1c23bd5.